### PR TITLE
Add dagger reflect to the same config that dagger is present in.

### DIFF
--- a/buildSrc/src/main/java/com/soundcloud/reflect/DaggerReflectPlugin.kt
+++ b/buildSrc/src/main/java/com/soundcloud/reflect/DaggerReflectPlugin.kt
@@ -24,12 +24,12 @@ class DaggerReflectPlugin : Plugin<Project> {
                 maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
             }
 
-            configurations.all {
+            configurations.all config@ {
                 dependencies.all {
                     // If we depend on the dagger runtime, also add the dagger reflect runtime.
                     if (group == daggerGroupId && name == "dagger") {
                         dependencies {
-                            add("implementation", "$reflectDaggerGroupId:dagger-reflect:${extension.daggerReflectVersion}")
+                            add(this@config.name, "$reflectDaggerGroupId:dagger-reflect:${extension.daggerReflectVersion}")
                         }
                     }
                 }


### PR DESCRIPTION
Otherwise if dagger is present in the `api` config, we might add dagger
reflect to `implementation` and then builds won't work.