### PR TITLE
Make small improvements to speedup build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,6 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
 container:
   image: gradle:5.6.2-jdk8
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,10 @@
 container:
-  image: gradle:jdk8
+  image: gradle:5.6.2-jdk8
 
 check_task:
   gradle_cache:
     folder: ~/.gradle/caches
-  check_script: ./gradlew tasks
+  check_script: gradle tasks
   cleanup_before_cache_script:
     - rm -rf ~/.gradle/caches/$GRADLE_VERSION/
     - rm -rf ~/.gradle/caches/transforms-1


### PR DESCRIPTION
Changes:
* Use gradle from the path to avoid distribution download
* Set depth clone to 1 to speed up repo clone on CI

Notes:
* I didn't have chance to test it since I don't have an account with Circus