### PR TITLE
Add support for full reflection.

### DIFF
--- a/buildSrc/src/main/java/com/soundcloud/reflect/DelectExtension.kt
+++ b/buildSrc/src/main/java/com/soundcloud/reflect/DelectExtension.kt
@@ -2,4 +2,13 @@ package com.soundcloud.reflect
 
 open class DelectExtension {
     var daggerReflectVersion = "0.2.0"
+    /**
+     * By default, we use the Reflect Annotation Processor to connect the App's code the the
+     * Dagger Reflect runtime as outlined in the partial reflection approach:
+     * https://github.com/jakewharton/dagger-reflect#partial-reflection
+     *
+     * Disable to use the full reflection approach. This requires changing the app's logic a bit.
+     * https://github.com/jakewharton/dagger-reflect#full-reflection
+     */
+    var addReflectAnnotationProcessor = true
 }

--- a/buildSrc/src/test/fixtures/java-module-full-reflect/build.gradle.kts
+++ b/buildSrc/src/test/fixtures/java-module-full-reflect/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    java
+    application
+}
+
+repositories {
+    mavenCentral()
+}
+
+application {
+    mainClassName = "com.delect.test.java.Starter"
+}
+
+dependencies {
+    annotationProcessor("com.google.dagger:dagger-compiler:2.24")
+    implementation("com.google.dagger:dagger:2.24")
+}

--- a/buildSrc/src/test/fixtures/java-module-full-reflect/src/main/java/com/delect/test/java/AppComponent.java
+++ b/buildSrc/src/test/fixtures/java-module-full-reflect/src/main/java/com/delect/test/java/AppComponent.java
@@ -1,0 +1,16 @@
+package com.delect.test.java;
+
+import dagger.Component;
+import dagger.Module;
+import dagger.Provides;
+
+@Component
+public interface AppComponent {
+
+    @Module
+    abstract class AppModule {
+        @Provides Foo provideFoo() {
+            return new Foo();
+        }
+    }
+}

--- a/buildSrc/src/test/fixtures/java-module-full-reflect/src/main/java/com/delect/test/java/Foo.java
+++ b/buildSrc/src/test/fixtures/java-module-full-reflect/src/main/java/com/delect/test/java/Foo.java
@@ -1,0 +1,6 @@
+package com.delect.test.java;
+
+public class Foo {
+    public Foo() {
+    }
+}

--- a/buildSrc/src/test/fixtures/java-module-full-reflect/src/main/java/com/delect/test/java/Starter.java
+++ b/buildSrc/src/test/fixtures/java-module-full-reflect/src/main/java/com/delect/test/java/Starter.java
@@ -1,0 +1,15 @@
+package com.delect.test.java;
+
+import dagger.Dagger;
+
+public class Starter {
+    public static void main(String[] args) {
+        AppComponent appComponent = Dagger.create(AppComponent.class);
+        try {
+            Class<?> daggerReflectClass = Class.forName("dagger.reflect.DaggerReflect");
+            System.out.println("dagger reflect class is available");
+        } catch (ClassNotFoundException e) {
+            System.out.println("dagger reflect class not available");
+        }
+    }
+}

--- a/buildSrc/src/test/java/com/soundcloud/reflect/DaggerReflectPluginIntegrationTest.kt
+++ b/buildSrc/src/test/java/com/soundcloud/reflect/DaggerReflectPluginIntegrationTest.kt
@@ -38,6 +38,59 @@ class DaggerReflectPluginIntegrationTest {
         assertThat(result.output).contains("dagger reflect class is available")
     }
 
+    @Test
+    fun `test no code generation fails compile when referencing generated code`() {
+        val fixtureName = "java-module"
+        testProjectDir.newFile("build.gradle").writeText("""
+            plugins {
+                id 'com.soundcloud.delect'
+            }
+            delect {
+                addReflectAnnotationProcessor = false
+            }
+        """.trimIndent())
+
+        writeSettingsGradle(fixtureName)
+        copyProjectFixture(fixtureName)
+        enableDaggerReflect()
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withPluginClasspath()
+            .withArguments("run")
+            .buildAndFail()
+
+        assertThat(result.output).contains("error: cannot find symbol\n" +
+                "        AppComponent appComponent = DaggerAppComponent.create();\n" +
+                "                                    ^\n" +
+                "  symbol:   variable DaggerAppComponent")
+    }
+
+    @Test
+    fun `test no code generation succeeds with full reflection`() {
+        val fixtureName = "java-module-full-reflect"
+        testProjectDir.newFile("build.gradle").writeText("""
+            plugins {
+                id 'com.soundcloud.delect'
+            }
+            delect {
+                addReflectAnnotationProcessor = false
+            }
+        """.trimIndent())
+
+        writeSettingsGradle(fixtureName)
+        copyProjectFixture(fixtureName)
+        enableDaggerReflect()
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withPluginClasspath()
+            .withArguments("run")
+            .build()
+
+        assertThat(result.output).contains("dagger reflect class is available")
+    }
+
     private fun setupJavaModuleTextFixtureAndDelectPlugin() {
         val fixtureName = "java-module"
         writePluginBuildGradle()


### PR DESCRIPTION
This adds an option to the delect extension `addReflectAnnotationProcessor`.
This can be disabled in order to use the full reflection approach as outlined
[here](https://github.com/jakewharton/dagger-reflect#full-reflection).
When disabled, the dagger annotation processors are automatically
removed from the build.

Fixes #22