### PR TITLE
Add test for configuration cache compatibility.

### DIFF
--- a/buildSrc/src/test/java/com/soundcloud/reflect/DaggerReflectPluginIntegrationTest.kt
+++ b/buildSrc/src/test/java/com/soundcloud/reflect/DaggerReflectPluginIntegrationTest.kt
@@ -97,6 +97,28 @@ class DaggerReflectPluginIntegrationTest {
         assertThat(result.output).contains("dagger reflect class is available")
     }
 
+    @Test
+    fun `is compatible with the configuration cache`() {
+        setupJavaModuleTextFixtureAndDelectPlugin()
+
+        enableDaggerReflect()
+        val runner = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withPluginClasspath()
+            .withGradleVersion("6.6")
+            .withArguments("run", "--configuration-cache")
+
+        val result = runner.build()
+        assertThat(result.output).contains("SUCCESS")
+        assertThat(result.output).contains("dagger reflect class is available")
+        assertThat(result.output).contains("Configuration cache entry stored.")
+
+        val resultTwo = runner.build()
+        assertThat(resultTwo.output).contains("SUCCESS")
+        assertThat(resultTwo.output).contains("dagger reflect class is available")
+        assertThat(resultTwo.output).contains("Reusing configuration cache.")
+    }
+
     private fun setupJavaModuleTextFixtureAndDelectPlugin() {
         val fixtureName = "java-module"
         writePluginBuildGradle()


### PR DESCRIPTION
This tests that the build does not generate any configuration cache warnings.
It does not mean that this plugin is fully compatible with the configuration cache. For example the reading of gradle properties is not compatible with the configuration cache but does not generate warnings.
